### PR TITLE
Fix compilation error for default build instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(NOT nlohmann_json_POPULATED)
     add_subdirectory(${nlohmann_json_SOURCE_DIR} ${nlohmann_json_BINARY_DIR})
 endif()
 
-target_include_directories(faiss PUBLIC ${nlohmann_json_SOURCE_DIR}/include)
+target_include_directories(faiss PRIVATE ${nlohmann_json_SOURCE_DIR}/include)
 
 find_package(ZLIB REQUIRED)
 target_link_libraries(faiss PUBLIC ${ZLIB_LIBRARIES})


### PR DESCRIPTION
Resolves #1.

The default build instructions include the following command:

```
cmake -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=OFF -DBUILD_TESTING=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release -B build
```

which results in the following error:

```
CMake Error in faiss/CMakeLists.txt:
  Target "faiss" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/acorn/build/_deps/nlohmann_json-src/include"

  which is prefixed in the build directory.


CMake Error in faiss/CMakeLists.txt:
  Target "faiss" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/acorn/build/_deps/nlohmann_json-src/include"

  which is prefixed in the build directory.Target "faiss"
  INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/acorn/build/_deps/nlohmann_json-src/include"

  which is prefixed in the source directory.
```

The solution, as proposed in #1, is to change the `CMakeList.txt` dependency 
 specified in `target_include_directories(faiss PUBLIC ${nlohmann_json_SOURCE_DIR}/include)` from `PUBLIC` to `PRIVATE`. 